### PR TITLE
Avoid "Exception without stack frame" on socket close

### DIFF
--- a/amqp.inc
+++ b/amqp.inc
@@ -415,7 +415,7 @@ class AMQPConnection extends AbstractChannel
             if($this->input)
                 $this->close();
 
-        if($this->sock)
+        if(is_resource($this->sock))
         {
           if($this->debug)
           {
@@ -457,7 +457,7 @@ class AMQPConnection extends AbstractChannel
                 $this->input = NULL;
             }
         
-        if($this->sock)
+        if(is_resource($this->sock))
         {
             if($this->debug)
             {


### PR DESCRIPTION
If the socket was already closed I'm getting "Exception without a stack frame" errors on do_close().
Checking for is_resource is more explicit and catches these.
